### PR TITLE
Fix: Improve flight search by incorporating date

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,31 +6,56 @@ function App() {
   const [flightNumberInput, setFlightNumberInput] = useState('');
   // Для MVP можна спростити і не використовувати поле для дати,
   // або додати пізніше. Пошук спершу лише за номером рейсу.
-  // const [dateInput, setDateInput] = useState(''); 
+  const [dateInput, setDateInput] = useState(''); 
   const [foundFlight, setFoundFlight] = useState(null);
   const [searchMessage, setSearchMessage] = useState('');
 
   const handleSearch = () => {
-  if (!flightNumberInput) {
-    setSearchMessage('Будь ласка, введіть номер рейсу.');
-    setFoundFlight(null);
-    return;
-  }
+    setFoundFlight(null); // Reset foundFlight at the beginning of each search
 
-  // Для MVP шукаємо лише за номером рейсу.
-  // Якщо будете додавати дату, розширте логіку пошуку.
-  const flight = flights.find(
-    (f) => f.flightNumber === flightNumberInput // && f.date === dateInput (якщо дата використовується)
-  );
+    if (!flightNumberInput) {
+      setSearchMessage('Будь ласка, введіть номер рейсу.');
+      return;
+    }
 
-  if (flight) {
-    setFoundFlight(flight);
-    setSearchMessage(''); // Очистити повідомлення, якщо рейс знайдено
-  } else {
-    setFoundFlight(null);
-    setSearchMessage(`Рейс ${flightNumberInput} не знайдено.`);
-  }
-};
+    if (dateInput) {
+      // Search by flight number and date
+      const flight = flights.find(
+        (f) => f.flightNumber === flightNumberInput && f.date === dateInput
+      );
+
+      if (flight) {
+        setFoundFlight(flight);
+        setSearchMessage('');
+      } else {
+        setSearchMessage(`Рейс ${flightNumberInput} на дату ${dateInput} не знайдено.`);
+      }
+    } else {
+      // Search by flight number only
+      const matchingFlights = flights.filter(
+        (f) => f.flightNumber === flightNumberInput
+      );
+
+      if (matchingFlights.length === 0) {
+        setSearchMessage(`Рейс ${flightNumberInput} не знайдено.`);
+      } else if (matchingFlights.length === 1) {
+        setFoundFlight(matchingFlights[0]);
+        setSearchMessage('');
+      } else {
+        // Multiple flights found for the same number on different dates
+        // Check if all found flights are on the same date (unlikely based on current data but good for robustness)
+        const uniqueDates = [...new Set(matchingFlights.map(f => f.date))];
+        if (uniqueDates.length > 1) {
+          setSearchMessage(`Знайдено декілька рейсів ${flightNumberInput} на різні дати. Будь ласка, вкажіть дату для уточнення.`);
+        } else {
+          // This case implies multiple flights with the same number and same date, which shouldn't happen with current data.
+          // Handling it defensively by showing the first one.
+          setFoundFlight(matchingFlights[0]);
+          setSearchMessage('');
+        }
+      }
+    }
+  };
 
   return (
   <div className="container">
@@ -42,14 +67,12 @@ function App() {
         onChange={(e) => setFlightNumberInput(e.target.value.toUpperCase())}
         placeholder="Номер рейсу (напр. WF101)"
       />
-      {/* Можна додати поле для дати пізніше
       <input
         type="text" // Або type="date" для кращого UX
         value={dateInput}
         onChange={(e) => setDateInput(e.target.value)}
         placeholder="Дата (YYYY-MM-DD)"
       />
-      */}
       <button onClick={handleSearch}>Знайти Рейс</button>
     </div>
 


### PR DESCRIPTION
The original flight search functionality only considered the flight number. This caused ambiguity when the same flight number existed on multiple dates, as only the first occurrence in the data was returned.

This commit introduces the following changes:
- Enables a date input field in the UI.
- Modifies the search logic to use both flight number and date when provided.
- If only a flight number is provided:
    - If the flight number is unique to one date, that flight's details are shown.
    - If the flight number exists on multiple dates, you are prompted to enter a date for clarification.
- Updates user feedback messages to be more specific based on the search criteria and outcome.

These changes address the 'diagnose' issue by making the flight search more precise and user-friendly, especially for flights with recurring numbers.